### PR TITLE
STOR-1353: UPSTREAM: 526: Add extra volume labels from command line option

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,6 +48,7 @@ var (
 	ecfsDescription                 = flag.String("ecfs-description", "", "Filestore multishare instance descrption. ecfs-version=<version>,image-project-id=<projectid>")
 	isRegional                      = flag.Bool("is-regional", false, "cluster is regional cluster")
 	gkeClusterName                  = flag.String("gke-cluster-name", "", "Cluster Name of the current GKE cluster driver is running on, required for multishare")
+	extraVolumeLabelsStr            = flag.String("extra-labels", "", "Extra labels to attach to each volume created. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'. See https://cloud.google.com/compute/docs/labeling-resources for details")
 
 	// Feature lock release specific parameters, only take effect when feature-lock-release is set to true.
 	featureLockRelease    = flag.Bool("feature-lock-release", false, "if set to true, the node driver will support Filestore lock release.")
@@ -89,6 +90,7 @@ func main() {
 	defer cancel()
 	var meta metadata.Service
 	var mm *metrics.MetricsManager
+	var extraVolumeLabels map[string]string
 	if *runController {
 		if *httpEndpoint != "" && metrics.IsGKEComponentVersionAvailable() {
 			mm = metrics.NewMetricsManager()
@@ -102,10 +104,18 @@ func main() {
 			}
 		}
 
+		extraVolumeLabels, err = util.ConvertLabelsStringToMap(*extraVolumeLabelsStr)
+		if err != nil {
+			klog.Fatalf("Bad extra volume labels: %v", err.Error())
+		}
+
 		provider, err = cloud.NewCloud(ctx, version, *cloudConfigFilePath, *primaryFilestoreServiceEndpoint, *testFilestoreServiceEndpoint)
 	} else {
 		if *nodeID == "" {
 			klog.Fatalf("nodeid cannot be empty for node service")
+		}
+		if len(*extraVolumeLabelsStr) > 0 {
+			klog.Fatalf("Extra volume labels provided but not running controller")
 		}
 
 		meta, err = metadataservice.NewMetadataService()
@@ -168,20 +178,21 @@ func main() {
 
 	mounter := mount.New("")
 	config := &driver.GCFSDriverConfig{
-		Name:             driverName,
-		Version:          version,
-		NodeName:         *nodeID,
-		RunController:    *runController,
-		RunNode:          *runNode,
-		Mounter:          mounter,
-		Cloud:            provider,
-		MetadataService:  meta,
-		EnableMultishare: *enableMultishare,
-		Metrics:          mm,
-		EcfsDescription:  *ecfsDescription,
-		IsRegional:       *isRegional,
-		ClusterName:      *gkeClusterName,
-		FeatureOptions:   featureOptions,
+		Name:              driverName,
+		Version:           version,
+		NodeName:          *nodeID,
+		RunController:     *runController,
+		RunNode:           *runNode,
+		Mounter:           mounter,
+		Cloud:             provider,
+		MetadataService:   meta,
+		EnableMultishare:  *enableMultishare,
+		Metrics:           mm,
+		EcfsDescription:   *ecfsDescription,
+		IsRegional:        *isRegional,
+		ClusterName:       *gkeClusterName,
+		FeatureOptions:    featureOptions,
+		ExtraVolumeLabels: extraVolumeLabels,
 	}
 
 	gcfsDriver, err := driver.NewGCFSDriver(config)

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -122,6 +122,7 @@ type controllerServerConfig struct {
 	isRegional           bool
 	clusterName          string
 	features             *GCFSDriverFeatureOptions
+	extraVolumeLabels    map[string]string
 }
 
 func newControllerServer(config *controllerServerConfig) csi.ControllerServer {
@@ -279,6 +280,10 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		labels, err := extractLabels(param, s.config.driver.config.Name)
 		if err != nil {
 			return nil, err
+		}
+		// Append extra lables from the command line option
+		for k, v := range s.config.extraVolumeLabels {
+			labels[k] = v
 		}
 		newFiler.Labels = labels
 

--- a/pkg/csi_driver/gcfs_driver.go
+++ b/pkg/csi_driver/gcfs_driver.go
@@ -54,21 +54,22 @@ const (
 )
 
 type GCFSDriverConfig struct {
-	Name             string          // Driver name
-	Version          string          // Driver version
-	NodeName         string          // Node name
-	RunController    bool            // Run CSI controller service
-	RunNode          bool            // Run CSI node service
-	Mounter          mount.Interface // Mount library
-	Cloud            *cloud.Cloud    // Cloud provider
-	MetadataService  metadataservice.Service
-	EnableMultishare bool
-	Reconciler       *MultishareReconciler
-	Metrics          *metrics.MetricsManager
-	EcfsDescription  string
-	IsRegional       bool
-	ClusterName      string
-	FeatureOptions   *GCFSDriverFeatureOptions
+	Name              string          // Driver name
+	Version           string          // Driver version
+	NodeName          string          // Node name
+	RunController     bool            // Run CSI controller service
+	RunNode           bool            // Run CSI node service
+	Mounter           mount.Interface // Mount library
+	Cloud             *cloud.Cloud    // Cloud provider
+	MetadataService   metadataservice.Service
+	EnableMultishare  bool
+	Reconciler        *MultishareReconciler
+	Metrics           *metrics.MetricsManager
+	EcfsDescription   string
+	IsRegional        bool
+	ClusterName       string
+	FeatureOptions    *GCFSDriverFeatureOptions
+	ExtraVolumeLabels map[string]string
 }
 
 type GCFSDriver struct {
@@ -181,17 +182,18 @@ func NewGCFSDriver(config *GCFSDriverConfig) (*GCFSDriver, error) {
 		}
 		// Configure controller server
 		driver.cs = newControllerServer(&controllerServerConfig{
-			driver:           driver,
-			fileService:      config.Cloud.File,
-			cloud:            config.Cloud,
-			volumeLocks:      util.NewVolumeLocks(),
-			enableMultishare: config.EnableMultishare,
-			reconciler:       config.Reconciler,
-			metricsManager:   config.Metrics,
-			ecfsDescription:  config.EcfsDescription,
-			isRegional:       config.IsRegional,
-			clusterName:      config.ClusterName,
-			features:         config.FeatureOptions,
+			driver:            driver,
+			fileService:       config.Cloud.File,
+			cloud:             config.Cloud,
+			volumeLocks:       util.NewVolumeLocks(),
+			enableMultishare:  config.EnableMultishare,
+			reconciler:        config.Reconciler,
+			metricsManager:    config.Metrics,
+			ecfsDescription:   config.EcfsDescription,
+			isRegional:        config.IsRegional,
+			clusterName:       config.ClusterName,
+			features:          config.FeatureOptions,
+			extraVolumeLabels: config.ExtraVolumeLabels,
 		})
 	}
 


### PR DESCRIPTION
Backport the upstream feature from the https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/526

This allows us to set the volume labels to all the PVs provisioned for a given cluster and then delete them automatically based on the label.