### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - test/**


### PR DESCRIPTION
Ignore the following k8s integration test errors. This test uses local files, and there's nothing valuable here for an attacker. If you're running the test, you already have access to the file paths that the test can access.

```
 ✗ [Low] Path Traversal
   ID: 9be0a38d-7502-4a52-9af1-d6d1434241b8 
   Path: test/k8s-integration/main.go, line 257 
   Info: Unsanitized input from a CLI argument flows into os.Rename, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to rename arbitrary files.
 ✗ [Low] Path Traversal
   ID: eaa87d1f-cdf7-477a-b724-7ad42fad444a 
   Path: test/k8s-integration/main.go, line 374 
   Info: Unsanitized input from a CLI argument flows into os.OpenFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to open arbitrary files.
 ✗ [Low] Path Traversal
   ID: d613156f-e9d6-4f2c-b2b9-c21ffb641deb 
   Path: test/k8s-integration/main.go, line 378 
   Info: Unsanitized input from a CLI argument flows into io.ioutil.ReadFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
 ✗ [Low] Path Traversal
   ID: bd5f9802-d0ea-4479-849c-eb4d5440b747 
   Path: test/k8s-integration/main.go, line 574 
   Info: Unsanitized input from a CLI argument flows into os.Open, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to open arbitrary files.
 ✗ [Low] Command Injection
   ID: 88626c69-6d46-45f3-93a5-76ce6301fd50 
   Path: test/k8s-integration/main.go, line 273 
   Info: Unsanitized input from a CLI argument flows into os.exec.Command, where it is used as a shell command. This may result in a Command Injection vulnerability.
 ✗ [Low] Command Injection
   ID: 0ac11d40-5a66-4266-bd15-00017330c5e8 
   Path: test/k8s-integration/main.go, line 288 
   Info: Unsanitized input from a CLI argument flows into os.exec.Command, where it is used as a shell command. This may result in a Command Injection vulnerability.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-gcp-filestore-csi-driver-master-security/1745954200140910592

/cc @openshift/storage
