### PR TITLE
CFE-1022: UPSTREAM: 640: Add labels from command line option to filestore backup resource

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -292,13 +292,9 @@ func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		}
 
 		// Add labels.
-		labels, err := extractLabels(param, s.config.driver.config.Name)
+		labels, err := extractLabels(param, s.config.extraVolumeLabels, s.config.driver.config.Name)
 		if err != nil {
 			return nil, file.StatusError(err)
-		}
-		// Append extra lables from the command line option
-		for k, v := range s.config.extraVolumeLabels {
-			labels[k] = v
 		}
 		newFiler.Labels = labels
 
@@ -838,7 +834,7 @@ func getZoneFromSegment(seg map[string]string) (string, error) {
 	return zone, nil
 }
 
-func extractLabels(parameters map[string]string, driverName string) (map[string]string, error) {
+func extractLabels(parameters, cliLabels map[string]string, driverName string) (map[string]string, error) {
 	labels := make(map[string]string)
 	scLables := make(map[string]string)
 	for k, v := range parameters {
@@ -859,12 +855,12 @@ func extractLabels(parameters map[string]string, driverName string) (map[string]
 	}
 
 	labels[tagKeyCreatedBy] = strings.ReplaceAll(driverName, ".", "_")
-	return mergeLabels(scLables, labels)
+	return mergeLabels(scLables, labels, cliLabels)
 }
 
-func mergeLabels(scLabels map[string]string, metedataLabels map[string]string) (map[string]string, error) {
+func mergeLabels(scLabels, metadataLabels, cliLabels map[string]string) (map[string]string, error) {
 	result := make(map[string]string)
-	for k, v := range metedataLabels {
+	for k, v := range metadataLabels {
 		result[k] = v
 	}
 
@@ -874,6 +870,14 @@ func mergeLabels(scLabels map[string]string, metedataLabels map[string]string) (
 		}
 
 		result[k] = v
+	}
+
+	// add labels from command line with precedence given to
+	// metadata and storage class labels in same order.
+	for k, v := range cliLabels {
+		if _, ok := result[k]; !ok {
+			result[k] = v
+		}
 	}
 
 	return result, nil
@@ -948,7 +952,7 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 	} else {
 		// create new backup
 
-		labels, err := extractBackupLabels(req.GetParameters(), s.config.driver.config.Name, req.Name)
+		labels, err := extractBackupLabels(req.GetParameters(), s.config.extraVolumeLabels, s.config.driver.config.Name, req.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -978,8 +982,8 @@ func (s *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSn
 
 }
 
-func extractBackupLabels(parameters map[string]string, driverName string, snapshotName string) (map[string]string, error) {
-	labels, err := extractLabels(parameters, driverName)
+func extractBackupLabels(parameters, cliLabels map[string]string, driverName string, snapshotName string) (map[string]string, error) {
+	labels, err := extractLabels(parameters, cliLabels, driverName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/csi_driver/multishare_controller_test.go
+++ b/pkg/csi_driver/multishare_controller_test.go
@@ -419,10 +419,15 @@ func TestGetShareRequestCapacity(t *testing.T) {
 }
 
 func TestExtractInstanceLabels(t *testing.T) {
+	var (
+		parameterLabels = "key1=value1,key2=value2"
+	)
+
 	tests := []struct {
 		name          string
 		params        map[string]string
 		driver        string
+		cliLabels     map[string]string
 		expectedLabel map[string]string
 		expectErr     bool
 	}{
@@ -451,10 +456,108 @@ func TestExtractInstanceLabels(t *testing.T) {
 				TagKeyClusterLocation:                  testLocation,
 			},
 		},
+		{
+			name:   "Parsing labels in storageClass fails(invalid KV separator(:) used)",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+				ParameterKeyLabels:             "key1:value1,key2:value2",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectedLabel: nil,
+			expectErr:     true,
+		},
+		{
+			name:   "storageClass labels contain reserved metadata label(storage_gke_io_created-by)",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+				ParameterKeyLabels:             "key1=value1,key2=value2,storage_gke_io_created-by=test_filestore",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectedLabel: nil,
+			expectErr:     true,
+		},
+		{
+			name:   "storageClass labels parameter not present, only the CLI labels are defined",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+			},
+			cliLabels: map[string]string{
+				"key3": "value3",
+				"key4": "value4",
+			},
+			expectedLabel: map[string]string{
+				"key3":                                 "value3",
+				"key4":                                 "value4",
+				tagKeyCreatedBy:                        testDrivernameLabelValue,
+				util.ParamMultishareInstanceScLabelKey: "testsc",
+				TagKeyClusterName:                      testClusterName,
+				TagKeyClusterLocation:                  testLocation,
+			},
+		},
+		{
+			name:   "CLI labels not defined, labels are defined only in storageClass object",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+				ParameterKeyLabels:             parameterLabels,
+			},
+			cliLabels: nil,
+			expectedLabel: map[string]string{
+				"key1":                                 "value1",
+				"key2":                                 "value2",
+				tagKeyCreatedBy:                        testDrivernameLabelValue,
+				util.ParamMultishareInstanceScLabelKey: "testsc",
+				TagKeyClusterName:                      testClusterName,
+				TagKeyClusterLocation:                  testLocation,
+			},
+		},
+		{
+			name:   "CLI labels and storageClass labels parameter not defined",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+			},
+			cliLabels: nil,
+			expectedLabel: map[string]string{
+				tagKeyCreatedBy:                        testDrivernameLabelValue,
+				util.ParamMultishareInstanceScLabelKey: "testsc",
+				TagKeyClusterName:                      testClusterName,
+				TagKeyClusterLocation:                  testLocation,
+			},
+		},
+		{
+			name:   "CLI labels and storageClass labels has duplicates",
+			driver: testDriverName,
+			params: map[string]string{
+				ParamMultishareInstanceScLabel: "testsc",
+				ParameterKeyLabels:             parameterLabels,
+			},
+			cliLabels: map[string]string{
+				"key1": "value1",
+				"key2": "value202",
+			},
+			expectedLabel: map[string]string{
+				"key1":                                 "value1",
+				"key2":                                 "value2",
+				tagKeyCreatedBy:                        testDrivernameLabelValue,
+				util.ParamMultishareInstanceScLabelKey: "testsc",
+				TagKeyClusterName:                      testClusterName,
+				TagKeyClusterLocation:                  testLocation,
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			label, err := extractInstanceLabels(tc.params, tc.driver, testClusterName, testLocation)
+			label, err := extractInstanceLabels(tc.params, tc.cliLabels, tc.driver, testClusterName, testLocation)
 			if tc.expectErr && err == nil {
 				t.Error("expected error, got none")
 			}
@@ -2843,6 +2946,30 @@ func TestCreateMultishareSnapshot(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "Parameters contain misconfigured labels(invalid KV separator(:) used)",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: "modeInstance/us-central1/myinstance/myshare",
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey: "backup",
+					"labels":                   "key1:value1",
+				},
+			},
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            testProject,
+					Location:           testRegion,
+					SourceInstanceName: testInstanceName1,
+					SourceShare:        testShareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     modeMultishare + "/" + testRegion + "/" + testInstanceName1 + "/" + testShareName,
+				},
+				state: "CREATING",
+			},
+			expectErr: true,
+		},
 		//Success test cases
 		{
 			name: "No existing backup",
@@ -2871,6 +2998,32 @@ func TestCreateMultishareSnapshot(t *testing.T) {
 				Name:           backupName,
 				Parameters: map[string]string{
 					util.VolumeSnapshotTypeKey: "backup",
+				},
+			},
+			features: features,
+			initialBackup: &BackupTestInfo{
+				backup: &file.BackupInfo{
+					Project:            testProject,
+					Location:           testRegion,
+					SourceInstanceName: testInstanceName1,
+					SourceShare:        testShareName,
+					Name:               backupName,
+					BackupURI:          defaultBackupUri,
+					SourceVolumeId:     modeMultishare + "/" + testRegion + "/" + testInstanceName1 + "/" + testShareName,
+				},
+				state: "READY",
+			},
+		},
+		{
+			// If the incorrect labels were added, labels processing will not happen for already
+			// existing backup resources.
+			name: "Existing backup found, in state READY. Labels will not be processed.",
+			req: &csi.CreateSnapshotRequest{
+				SourceVolumeId: defaultSourceVolumeID,
+				Name:           backupName,
+				Parameters: map[string]string{
+					util.VolumeSnapshotTypeKey: "backup",
+					"labels":                   "key1:value1",
 				},
 			},
 			features: features,

--- a/pkg/csi_driver/reconciler.go
+++ b/pkg/csi_driver/reconciler.go
@@ -485,7 +485,7 @@ func (recon *MultishareReconciler) generateNewMultishareInstance(instanceInfo *v
 		}
 	}
 
-	labels, err := extractInstanceLabels(params, recon.config.Name, recon.config.ClusterName, clusterLocation)
+	labels, err := extractInstanceLabels(params, recon.config.ExtraVolumeLabels, recon.config.Name, recon.config.ClusterName, clusterLocation)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}


### PR DESCRIPTION
Backport of the upstream change https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/pull/640 which fixes the issue https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/issues/639.

This change enables adding labels from command line option to filestore backup resource created for an OpenShift Cluster.